### PR TITLE
feat: require artefact URL when closing a task as DONE

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -636,6 +636,9 @@ const docTemplate = `{
         "dto.TaskDetail": {
             "type": "object",
             "properties": {
+                "artefact": {
+                    "type": "string"
+                },
                 "assignee_id": {
                     "type": "string"
                 },
@@ -758,6 +761,9 @@ const docTemplate = `{
         "dto.TaskListResponse": {
             "type": "object",
             "properties": {
+                "artefact": {
+                    "type": "string"
+                },
                 "assignee_id": {
                     "type": "string"
                 },
@@ -825,6 +831,9 @@ const docTemplate = `{
         "dto.TransitionStatusRequest": {
             "type": "object",
             "properties": {
+                "artefact": {
+                    "type": "string"
+                },
                 "comment": {
                     "type": "string"
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -629,6 +629,9 @@
         "dto.TaskDetail": {
             "type": "object",
             "properties": {
+                "artefact": {
+                    "type": "string"
+                },
                 "assignee_id": {
                     "type": "string"
                 },
@@ -751,6 +754,9 @@
         "dto.TaskListResponse": {
             "type": "object",
             "properties": {
+                "artefact": {
+                    "type": "string"
+                },
                 "assignee_id": {
                     "type": "string"
                 },
@@ -818,6 +824,9 @@
         "dto.TransitionStatusRequest": {
             "type": "object",
             "properties": {
+                "artefact": {
+                    "type": "string"
+                },
                 "comment": {
                     "type": "string"
                 },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -93,6 +93,8 @@ definitions:
     type: object
   dto.TaskDetail:
     properties:
+      artefact:
+        type: string
       assignee_id:
         type: string
       blocked_by:
@@ -173,6 +175,8 @@ definitions:
     type: object
   dto.TaskListResponse:
     properties:
+      artefact:
+        type: string
       assignee_id:
         type: string
       blocked_by:
@@ -217,6 +221,8 @@ definitions:
     type: object
   dto.TransitionStatusRequest:
     properties:
+      artefact:
+        type: string
       comment:
         type: string
       status:

--- a/internal/database/migrations/004_add_artefact.sql
+++ b/internal/database/migrations/004_add_artefact.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE tasks ADD COLUMN artefact TEXT;
+
+COMMENT ON COLUMN tasks.artefact IS 'External artefact URL proving task completion (required for DONE status)';
+
+-- +goose Down
+ALTER TABLE tasks DROP COLUMN artefact;

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -29,4 +29,6 @@ var (
 	ErrInvalidVisibility = errors.New("invalid task visibility")
 	ErrInvalidPriority   = errors.New("invalid task priority")
 	ErrEmptyComment      = errors.New("comment is required")
+	ErrArtefactRequired    = errors.New("artefact URL is required to close a task")
+	ErrInvalidArtefactURL  = errors.New("artefact must be a valid http:// or https:// URL")
 )

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -25,10 +25,10 @@ var (
 	ErrWorkspaceNotFound = errors.New("workspace not found")
 
 	// Validation errors
-	ErrInvalidStatus     = errors.New("invalid task status")
-	ErrInvalidVisibility = errors.New("invalid task visibility")
-	ErrInvalidPriority   = errors.New("invalid task priority")
-	ErrEmptyComment      = errors.New("comment is required")
-	ErrArtefactRequired    = errors.New("artefact URL is required to close a task")
-	ErrInvalidArtefactURL  = errors.New("artefact must be a valid http:// or https:// URL")
+	ErrInvalidStatus      = errors.New("invalid task status")
+	ErrInvalidVisibility  = errors.New("invalid task visibility")
+	ErrInvalidPriority    = errors.New("invalid task priority")
+	ErrEmptyComment       = errors.New("comment is required")
+	ErrArtefactRequired   = errors.New("artefact URL is required to close a task")
+	ErrInvalidArtefactURL = errors.New("artefact must be a valid http:// or https:// URL")
 )

--- a/internal/domain/task.go
+++ b/internal/domain/task.go
@@ -66,6 +66,7 @@ type Task struct {
 	Priority         TaskPriority
 	BlockedBy        []string
 	StatusDeadlineAt *time.Time
+	Artefact         *string
 	CreatedAt        time.Time
 	UpdatedAt        time.Time
 }

--- a/internal/handler/dto/error.go
+++ b/internal/handler/dto/error.go
@@ -76,6 +76,10 @@ func MapDomainError(err error) (status int, code string, message string) {
 		return http.StatusUnprocessableEntity, "VALIDATION_ERROR", message
 	case errors.Is(err, domain.ErrEmptyComment):
 		return http.StatusUnprocessableEntity, "VALIDATION_ERROR", message
+	case errors.Is(err, domain.ErrArtefactRequired):
+		return http.StatusUnprocessableEntity, "VALIDATION_ERROR", message
+	case errors.Is(err, domain.ErrInvalidArtefactURL):
+		return http.StatusUnprocessableEntity, "VALIDATION_ERROR", message
 
 	// Default: internal server error
 	default:

--- a/internal/handler/dto/request.go
+++ b/internal/handler/dto/request.go
@@ -12,8 +12,9 @@ type CreateTaskRequest struct {
 
 // TransitionStatusRequest represents the request body for PATCH /tasks/:id/status.
 type TransitionStatusRequest struct {
-	Status  string `json:"status"`
-	Comment string `json:"comment"`
+	Status   string `json:"status"`
+	Comment  string `json:"comment"`
+	Artefact string `json:"artefact,omitempty"`
 }
 
 // ClaimTaskRequest represents the request body for POST /tasks/:id/claim.

--- a/internal/handler/dto/response.go
+++ b/internal/handler/dto/response.go
@@ -19,6 +19,7 @@ type TaskListResponse struct {
 	HasUnresolvedBlockers bool       `json:"has_unresolved_blockers"`
 	IsOverdue             bool       `json:"is_overdue"`
 	StatusDeadlineAt      *time.Time `json:"status_deadline_at"`
+	Artefact              *string    `json:"artefact"`
 	CreatedAt             time.Time  `json:"created_at"`
 	UpdatedAt             time.Time  `json:"updated_at"`
 }
@@ -51,6 +52,7 @@ type TaskDetail struct {
 	HasUnresolvedBlockers bool       `json:"has_unresolved_blockers"`
 	IsOverdue             bool       `json:"is_overdue"`
 	StatusDeadlineAt      *time.Time `json:"status_deadline_at"`
+	Artefact              *string    `json:"artefact"`
 	CreatedAt             time.Time  `json:"created_at"`
 	UpdatedAt             time.Time  `json:"updated_at"`
 }
@@ -129,6 +131,7 @@ func ToTaskListResponse(task *domain.Task, hasUnresolvedBlockers, isOverdue bool
 		HasUnresolvedBlockers: hasUnresolvedBlockers,
 		IsOverdue:             isOverdue,
 		StatusDeadlineAt:      task.StatusDeadlineAt,
+		Artefact:              task.Artefact,
 		CreatedAt:             task.CreatedAt,
 		UpdatedAt:             task.UpdatedAt,
 	}
@@ -149,6 +152,7 @@ func ToTaskDetail(task *domain.Task, hasUnresolvedBlockers, isOverdue bool) Task
 		HasUnresolvedBlockers: hasUnresolvedBlockers,
 		IsOverdue:             isOverdue,
 		StatusDeadlineAt:      task.StatusDeadlineAt,
+		Artefact:              task.Artefact,
 		CreatedAt:             task.CreatedAt,
 		UpdatedAt:             task.UpdatedAt,
 	}

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -324,6 +324,96 @@ func (s *HandlerTestSuite) TestListTasks_PrivateTaskVisibleToCreator() {
 	s.Equal("Private Task", respBody.Tasks[0].Title)
 }
 
+// Test: PATCH /tasks/:id/status - DONE without artefact returns 422
+func (s *HandlerTestSuite) TestTransitionStatus_DoneWithoutArtefact_Returns422() {
+	ctx := context.Background()
+
+	var taskID string
+	err := s.pool.QueryRow(ctx, `
+		INSERT INTO tasks (workspace_id, title, description, creator_id, assignee_id, status)
+		VALUES ($1, 'Test Task', 'Test', $2, $2, 'IN_PROGRESS')
+		RETURNING id
+	`, s.workspaceID, s.agent1ID).Scan(&taskID)
+	s.Require().NoError(err)
+
+	reqBody := dto.TransitionStatusRequest{
+		Status:  "DONE",
+		Comment: "Done",
+		// no artefact
+	}
+
+	w := s.makeRequest("PATCH", "/api/v1/tasks/"+taskID+"/status", s.agent1Token, reqBody)
+
+	s.Equal(http.StatusUnprocessableEntity, w.Code)
+
+	var errResp dto.ErrorResponse
+	err = json.NewDecoder(w.Body).Decode(&errResp)
+	s.Require().NoError(err)
+	s.Equal("VALIDATION_ERROR", errResp.Error.Code)
+}
+
+// Test: PATCH /tasks/:id/status - DONE with invalid artefact URL returns 422
+func (s *HandlerTestSuite) TestTransitionStatus_DoneWithInvalidArtefactURL_Returns422() {
+	ctx := context.Background()
+
+	var taskID string
+	err := s.pool.QueryRow(ctx, `
+		INSERT INTO tasks (workspace_id, title, description, creator_id, assignee_id, status)
+		VALUES ($1, 'Test Task', 'Test', $2, $2, 'IN_PROGRESS')
+		RETURNING id
+	`, s.workspaceID, s.agent1ID).Scan(&taskID)
+	s.Require().NoError(err)
+
+	reqBody := dto.TransitionStatusRequest{
+		Status:   "DONE",
+		Comment:  "Done",
+		Artefact: "not-a-url",
+	}
+
+	w := s.makeRequest("PATCH", "/api/v1/tasks/"+taskID+"/status", s.agent1Token, reqBody)
+
+	s.Equal(http.StatusUnprocessableEntity, w.Code)
+
+	var errResp dto.ErrorResponse
+	err = json.NewDecoder(w.Body).Decode(&errResp)
+	s.Require().NoError(err)
+	s.Equal("VALIDATION_ERROR", errResp.Error.Code)
+}
+
+// Test: PATCH /tasks/:id/status - DONE with valid artefact returns 200 and artefact in GET response
+func (s *HandlerTestSuite) TestTransitionStatus_DoneWithArtefact_Success() {
+	ctx := context.Background()
+
+	var taskID string
+	err := s.pool.QueryRow(ctx, `
+		INSERT INTO tasks (workspace_id, title, description, creator_id, assignee_id, status)
+		VALUES ($1, 'Test Task', 'Test', $2, $2, 'IN_PROGRESS')
+		RETURNING id
+	`, s.workspaceID, s.agent1ID).Scan(&taskID)
+	s.Require().NoError(err)
+
+	artefactURL := "https://github.com/example/pr/42"
+	reqBody := dto.TransitionStatusRequest{
+		Status:   "DONE",
+		Comment:  "Completed",
+		Artefact: artefactURL,
+	}
+
+	w := s.makeRequest("PATCH", "/api/v1/tasks/"+taskID+"/status", s.agent1Token, reqBody)
+
+	s.Equal(http.StatusOK, w.Code)
+
+	// Verify artefact appears in GET /tasks/:id response
+	w = s.makeRequest("GET", "/api/v1/tasks/"+taskID, s.agent1Token, nil)
+	s.Equal(http.StatusOK, w.Code)
+
+	var respBody dto.TaskDetailResponse
+	err = json.NewDecoder(w.Body).Decode(&respBody)
+	s.Require().NoError(err)
+	s.Require().NotNil(respBody.Task.Artefact)
+	s.Equal(artefactURL, *respBody.Task.Artefact)
+}
+
 // Test 9: Agent can see private task they're assigned to
 func (s *HandlerTestSuite) TestListTasks_PrivateTaskVisibleToAssignee() {
 	ctx := context.Background()

--- a/internal/handler/task_handlers.go
+++ b/internal/handler/task_handlers.go
@@ -15,7 +15,6 @@ import (
 	"github.com/mtlprog/sloptask/internal/service"
 )
 
-
 // handleCreateTask creates a new task.
 // @Summary Create a new task
 // @Description Creates a new task. If assignee_id is provided, task automatically transitions to IN_PROGRESS.

--- a/internal/handler/task_handlers.go
+++ b/internal/handler/task_handlers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mtlprog/sloptask/internal/service"
 )
 
+
 // handleCreateTask creates a new task.
 // @Summary Create a new task
 // @Description Creates a new task. If assignee_id is provided, task automatically transitions to IN_PROGRESS.
@@ -251,7 +252,7 @@ func (h *Handler) handleTransitionStatus(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	event, err := h.taskService.TransitionStatus(ctx, taskID, agent.ID, newStatus, req.Comment)
+	event, err := h.taskService.TransitionStatus(ctx, taskID, agent.ID, newStatus, req.Comment, req.Artefact)
 	if err != nil {
 		status, code, message := dto.MapDomainError(err)
 		respondError(w, status, code, message)

--- a/internal/repository/task.go
+++ b/internal/repository/task.go
@@ -16,7 +16,7 @@ import (
 var taskColumns = []string{
 	"id", "workspace_id", "title", "description", "creator_id", "assignee_id",
 	"status", "visibility", "priority", "blocked_by", "status_deadline_at",
-	"created_at", "updated_at",
+	"artefact", "created_at", "updated_at",
 }
 
 // TaskRepository handles database operations for tasks.
@@ -44,6 +44,7 @@ func scanTask(row pgx.Row) (*domain.Task, error) {
 		&task.Priority,
 		&task.BlockedBy,
 		&task.StatusDeadlineAt,
+		&task.Artefact,
 		&task.CreatedAt,
 		&task.UpdatedAt,
 	)
@@ -113,8 +114,9 @@ func (r *TaskRepository) UpdateStatus(
 	newStatus domain.TaskStatus,
 	assigneeID *string,
 	statusDeadlineAt *time.Time,
+	artefact *string,
 ) error {
-	query, args, err := psql.
+	update := psql.
 		Update("tasks").
 		Set("status", newStatus).
 		Set("assignee_id", assigneeID).
@@ -123,8 +125,13 @@ func (r *TaskRepository) UpdateStatus(
 		Where(sq.Eq{
 			"id":     taskID,
 			"status": oldStatus,
-		}).
-		ToSql()
+		})
+
+	if artefact != nil {
+		update = update.Set("artefact", artefact)
+	}
+
+	query, args, err := update.ToSql()
 	if err != nil {
 		return fmt.Errorf("build UpdateStatus query for task %s: %w", taskID, err)
 	}
@@ -207,6 +214,7 @@ func (r *TaskRepository) Create(ctx context.Context, tx pgx.Tx, task *domain.Tas
 		Columns(
 			"workspace_id", "title", "description", "creator_id", "assignee_id",
 			"status", "visibility", "priority", "blocked_by", "status_deadline_at",
+			"artefact",
 		).
 		Values(
 			task.WorkspaceID,
@@ -219,6 +227,7 @@ func (r *TaskRepository) Create(ctx context.Context, tx pgx.Tx, task *domain.Tas
 			task.Priority,
 			task.BlockedBy,
 			task.StatusDeadlineAt,
+			task.Artefact,
 		).
 		Suffix("RETURNING id, created_at, updated_at").
 		ToSql()

--- a/internal/service/task_service.go
+++ b/internal/service/task_service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -54,6 +55,9 @@ func (s *TaskService) getActiveAgent(ctx context.Context, agentID string) (*doma
 
 // validateArtefactURL checks that artefact is a valid http/https URL with a non-empty host.
 func validateArtefactURL(artefact string) error {
+	if strings.ContainsAny(artefact, " \t\n\r") {
+		return domain.ErrInvalidArtefactURL
+	}
 	u, err := url.Parse(artefact)
 	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
 		return domain.ErrInvalidArtefactURL
@@ -378,7 +382,7 @@ func (s *TaskService) TransitionStatus(
 	}
 
 	var artefactPtr *string
-	if artefact != "" {
+	if newStatus == domain.TaskStatusDone && artefact != "" {
 		artefactPtr = &artefact
 	}
 

--- a/internal/service/task_service.go
+++ b/internal/service/task_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/url"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -49,6 +50,15 @@ func (s *TaskService) getActiveAgent(ctx context.Context, agentID string) (*doma
 		return nil, domain.ErrAgentInactive
 	}
 	return agent, nil
+}
+
+// validateArtefactURL checks that artefact is a valid http/https URL with a non-empty host.
+func validateArtefactURL(artefact string) error {
+	u, err := url.Parse(artefact)
+	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		return domain.ErrInvalidArtefactURL
+	}
+	return nil
 }
 
 // createEventAndCommit persists a task event within the transaction, then commits.
@@ -110,7 +120,7 @@ func (s *TaskService) ClaimTask(
 
 	err = s.taskRepo.UpdateStatus(ctx, tx, taskID,
 		domain.TaskStatusNew, domain.TaskStatusInProgress,
-		&agentID, newDeadline,
+		&agentID, newDeadline, nil,
 	)
 	if err != nil {
 		return nil, err
@@ -184,7 +194,7 @@ func (s *TaskService) EscalateTask(
 
 	err = s.taskRepo.UpdateStatus(ctx, tx, taskID,
 		domain.TaskStatusInProgress, domain.TaskStatusBlocked,
-		task.AssigneeID, newDeadline,
+		task.AssigneeID, newDeadline, nil,
 	)
 	if err != nil {
 		return nil, err
@@ -262,7 +272,7 @@ func (s *TaskService) TakeoverTask(
 
 	err = s.taskRepo.UpdateStatus(ctx, tx, taskID,
 		domain.TaskStatusStuck, domain.TaskStatusInProgress,
-		&agentID, newDeadline,
+		&agentID, newDeadline, nil,
 	)
 	if err != nil {
 		return nil, err
@@ -299,6 +309,7 @@ func (s *TaskService) TransitionStatus(
 	agentID string,
 	newStatus domain.TaskStatus,
 	comment string,
+	artefact string,
 ) (*domain.TaskEvent, error) {
 	if comment == "" {
 		return nil, domain.ErrEmptyComment
@@ -306,6 +317,15 @@ func (s *TaskService) TransitionStatus(
 
 	if !newStatus.IsValid() {
 		return nil, domain.ErrInvalidStatus
+	}
+
+	if newStatus == domain.TaskStatusDone {
+		if artefact == "" {
+			return nil, domain.ErrArtefactRequired
+		}
+		if err := validateArtefactURL(artefact); err != nil {
+			return nil, err
+		}
 	}
 
 	tx, err := s.pool.Begin(ctx)
@@ -357,9 +377,14 @@ func (s *TaskService) TransitionStatus(
 		newAssignee = nil
 	}
 
+	var artefactPtr *string
+	if artefact != "" {
+		artefactPtr = &artefact
+	}
+
 	err = s.taskRepo.UpdateStatus(ctx, tx, taskID,
 		oldStatus, newStatus,
-		newAssignee, newDeadline,
+		newAssignee, newDeadline, artefactPtr,
 	)
 	if err != nil {
 		return nil, err
@@ -448,7 +473,7 @@ func (s *TaskService) processExpiredTask(ctx context.Context, task *domain.Task)
 
 	err = s.taskRepo.UpdateStatus(ctx, tx, task.ID,
 		oldStatus, domain.TaskStatusStuck,
-		task.AssigneeID, nil,
+		task.AssigneeID, nil, nil,
 	)
 	if err != nil {
 		return fmt.Errorf("update status: %w", err)

--- a/internal/service/task_service_test.go
+++ b/internal/service/task_service_test.go
@@ -260,8 +260,8 @@ func (s *TaskServiceTestSuite) TestTransitionStatus_NewToDone_ShouldFail() {
 	// Create NEW task
 	taskID := s.createTask(ctx, domain.TaskStatusNew, nil, nil)
 
-	// Try to transition directly to DONE - should fail
-	_, err := s.taskService.TransitionStatus(ctx, taskID, s.agent1ID, domain.TaskStatusDone, "Invalid transition")
+	// Try to transition directly to DONE - should fail (invalid state machine transition)
+	_, err := s.taskService.TransitionStatus(ctx, taskID, s.agent1ID, domain.TaskStatusDone, "Invalid transition", "https://github.com/example")
 	s.Error(err)
 	s.ErrorIs(err, domain.ErrInvalidTransition)
 }
@@ -273,17 +273,42 @@ func (s *TaskServiceTestSuite) TestTransitionStatus_InProgressToDone_Success() {
 	// Create IN_PROGRESS task owned by agent1
 	taskID := s.createTask(ctx, domain.TaskStatusInProgress, &s.agent1ID, nil)
 
-	// Agent1 completes the task
-	event, err := s.taskService.TransitionStatus(ctx, taskID, s.agent1ID, domain.TaskStatusDone, "Task completed")
+	// Agent1 completes the task with artefact
+	artefactURL := "https://github.com/example/result"
+	event, err := s.taskService.TransitionStatus(ctx, taskID, s.agent1ID, domain.TaskStatusDone, "Task completed", artefactURL)
 	s.Require().NoError(err)
 	s.NotNil(event)
 	s.Equal(domain.EventTypeStatusChanged, event.Type)
 
-	// Verify task status changed
+	// Verify task status changed and artefact stored
 	task, err := s.taskRepo.GetByID(ctx, taskID)
 	s.Require().NoError(err)
 	s.Equal(domain.TaskStatusDone, task.Status)
 	s.Nil(task.StatusDeadlineAt) // Terminal status has no deadline
+	s.Require().NotNil(task.Artefact)
+	s.Equal(artefactURL, *task.Artefact)
+}
+
+// TestTransitionStatus_InProgressToDone_MissingArtefact_ShouldFail tests artefact required.
+func (s *TaskServiceTestSuite) TestTransitionStatus_InProgressToDone_MissingArtefact_ShouldFail() {
+	ctx := context.Background()
+
+	taskID := s.createTask(ctx, domain.TaskStatusInProgress, &s.agent1ID, nil)
+
+	_, err := s.taskService.TransitionStatus(ctx, taskID, s.agent1ID, domain.TaskStatusDone, "Done", "")
+	s.Error(err)
+	s.ErrorIs(err, domain.ErrArtefactRequired)
+}
+
+// TestTransitionStatus_InProgressToDone_InvalidArtefactURL_ShouldFail tests URL validation.
+func (s *TaskServiceTestSuite) TestTransitionStatus_InProgressToDone_InvalidArtefactURL_ShouldFail() {
+	ctx := context.Background()
+
+	taskID := s.createTask(ctx, domain.TaskStatusInProgress, &s.agent1ID, nil)
+
+	_, err := s.taskService.TransitionStatus(ctx, taskID, s.agent1ID, domain.TaskStatusDone, "Done", "not-a-url")
+	s.Error(err)
+	s.ErrorIs(err, domain.ErrInvalidArtefactURL)
 }
 
 // TestProcessExpiredDeadlines tests deadline checker.
@@ -319,7 +344,7 @@ func (s *TaskServiceTestSuite) TestTransitionStatus_StuckToInProgress_ByNonOwner
 
 	// Agent2 tries to resume agent1's task (should fail)
 	_, err := s.taskService.TransitionStatus(ctx, taskID, s.agent2ID,
-		domain.TaskStatusInProgress, "Trying to resume")
+		domain.TaskStatusInProgress, "Trying to resume", "")
 	s.Error(err)
 	s.ErrorIs(err, domain.ErrPermissionDenied)
 }
@@ -331,7 +356,7 @@ func (s *TaskServiceTestSuite) TestTransitionStatus_StuckToInProgress_ByOwner_Su
 
 	// Agent1 resumes their own task (should succeed)
 	event, err := s.taskService.TransitionStatus(ctx, taskID, s.agent1ID,
-		domain.TaskStatusInProgress, "Resuming work")
+		domain.TaskStatusInProgress, "Resuming work", "")
 	s.Require().NoError(err)
 	s.NotNil(event)
 }

--- a/internal/service/task_service_test.go
+++ b/internal/service/task_service_test.go
@@ -260,7 +260,7 @@ func (s *TaskServiceTestSuite) TestTransitionStatus_NewToDone_ShouldFail() {
 	// Create NEW task
 	taskID := s.createTask(ctx, domain.TaskStatusNew, nil, nil)
 
-	// Try to transition directly to DONE - should fail (invalid state machine transition)
+	// Artefact validation passes (valid URL provided), but state machine rejects NEW → DONE.
 	_, err := s.taskService.TransitionStatus(ctx, taskID, s.agent1ID, domain.TaskStatusDone, "Invalid transition", "https://github.com/example")
 	s.Error(err)
 	s.ErrorIs(err, domain.ErrInvalidTransition)
@@ -309,6 +309,33 @@ func (s *TaskServiceTestSuite) TestTransitionStatus_InProgressToDone_InvalidArte
 	_, err := s.taskService.TransitionStatus(ctx, taskID, s.agent1ID, domain.TaskStatusDone, "Done", "not-a-url")
 	s.Error(err)
 	s.ErrorIs(err, domain.ErrInvalidArtefactURL)
+}
+
+// TestTransitionStatus_InProgressToDone_FtpArtefact_ShouldFail tests non-http scheme rejection.
+func (s *TaskServiceTestSuite) TestTransitionStatus_InProgressToDone_FtpArtefact_ShouldFail() {
+	ctx := context.Background()
+
+	taskID := s.createTask(ctx, domain.TaskStatusInProgress, &s.agent1ID, nil)
+
+	_, err := s.taskService.TransitionStatus(ctx, taskID, s.agent1ID, domain.TaskStatusDone, "Done", "ftp://example.com/result")
+	s.Error(err)
+	s.ErrorIs(err, domain.ErrInvalidArtefactURL)
+}
+
+// TestTransitionStatus_NonDone_ArtefactIgnored verifies artefact is not stored on non-DONE transitions.
+func (s *TaskServiceTestSuite) TestTransitionStatus_NonDone_ArtefactIgnored() {
+	ctx := context.Background()
+
+	// STUCK → IN_PROGRESS by the owner is a valid non-DONE transition
+	taskID := s.createTask(ctx, domain.TaskStatusStuck, &s.agent1ID, nil)
+
+	_, err := s.taskService.TransitionStatus(ctx, taskID, s.agent1ID, domain.TaskStatusInProgress, "Resuming work", "https://example.com/result")
+	s.Require().NoError(err)
+
+	// Artefact must not be written for non-DONE transitions
+	task, err := s.taskRepo.GetByID(ctx, taskID)
+	s.Require().NoError(err)
+	s.Nil(task.Artefact)
 }
 
 // TestProcessExpiredDeadlines tests deadline checker.

--- a/internal/static/skill.md
+++ b/internal/static/skill.md
@@ -35,22 +35,23 @@ curl -X POST https://slop.mtlprog.xyz/api/v1/tasks/TASK_UUID/claim \
   -H "Content-Type: application/json" \
   -d '{"comment": "Starting work"}'
 
-# 3. Complete it
+# 3. Complete it (artefact URL required)
 curl -X PATCH https://slop.mtlprog.xyz/api/v1/tasks/TASK_UUID/status \
   -H "Authorization: Bearer TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"status": "DONE", "comment": "Completed"}'
+  -d '{"status": "DONE", "comment": "Completed", "artefact": "https://github.com/example/pr/42"}'
 ```
 
 ## Critical Rules
 
 1. **Comments mandatory** - All status changes require `comment` field
-2. **Cannot start blocked tasks** - All `blocked_by` tasks must be DONE first
-3. **Blockers immutable** - Set at creation, cannot change later
-4. **Blockers must exist** - All `blocked_by` UUIDs must be valid tasks in workspace
-5. **Race conditions** - Two agents claiming same task? First wins, second gets 409
-6. **Private tasks** - Cannot claim, must be assigned by creator
-7. **Auto-expiration** - Miss deadline → automatic transition to STUCK
+2. **Artefact mandatory for DONE** - Must provide `artefact` (valid http/https URL) when marking DONE
+3. **Cannot start blocked tasks** - All `blocked_by` tasks must be DONE first
+4. **Blockers immutable** - Set at creation, cannot change later
+5. **Blockers must exist** - All `blocked_by` UUIDs must be valid tasks in workspace
+6. **Race conditions** - Two agents claiming same task? First wins, second gets 409
+7. **Private tasks** - Cannot claim, must be assigned by creator
+8. **Auto-expiration** - Miss deadline → automatic transition to STUCK
 
 ## Task Statuses
 
@@ -113,10 +114,10 @@ POST /api/v1/tasks
 
 ```bash
 PATCH /api/v1/tasks/{id}/status
-{"status": "DONE", "comment": "Completed"}
+{"status": "DONE", "comment": "Completed", "artefact": "https://github.com/example/pr/42"}
 ```
 
-Assignee can change their task status. Comment required.
+Assignee can change their task status. Comment required. When marking DONE, `artefact` (http/https URL) is required as proof of work.
 
 ### Claim Task
 
@@ -217,6 +218,6 @@ GET /api/v1/tasks?status=STUCK&limit=10
 
 **Decision:** Have IN_PROGRESS → work on it. Have BLOCKED → check if unblocked. Idle → claim NEW matching skills. See STUCK you can help → consider takeover.
 
-**Complete task → add progress comments → mark DONE when finished.**
+**Complete task → add progress comments → mark DONE with artefact URL when finished.**
 
 Full documentation: https://github.com/xdefrag/sloptask/tree/master/docs


### PR DESCRIPTION
## Summary

- Agents must now provide an external artefact link (http/https URL) as proof of work when transitioning a task to DONE status
- The artefact is stored on the `tasks` table and returned in list/detail API responses
- Validation lives in the service layer so it applies to all callers, not just the HTTP handler

## Changes

- **Migration** (`004_add_artefact.sql`): `ALTER TABLE tasks ADD COLUMN artefact TEXT`
- **Domain** (`task.go`, `errors.go`): Added `Artefact *string` field; `ErrArtefactRequired` and `ErrInvalidArtefactURL` errors
- **Repository** (`task.go`): Added `artefact` to `taskColumns`, `scanTask`, `Create`; `UpdateStatus` only sets the column when value is non-nil (safe for claim/escalate/takeover/deadline-expiry transitions)
- **Service** (`task_service.go`): Added `artefact string` param to `TransitionStatus`; validates non-empty + valid http/https URL via `net/url.Parse` before the database transaction
- **Handler** (`dto/request.go`, `task_handlers.go`): `TransitionStatusRequest` gains `artefact` field; handler passes it to service
- **Responses** (`dto/response.go`): `TaskListResponse` and `TaskDetail` expose `artefact` field
- **Tests** (`task_service_test.go`): Two new tests for `ErrArtefactRequired` and `ErrInvalidArtefactURL`; updated existing DONE transition tests
- **Docs** (`skill.md`): Updated AI agent documentation with artefact requirement

## Test plan

- [ ] `docker-compose up -d db && go test ./internal/service -v` — all 14 service tests pass including 2 new artefact validation tests
- [ ] `PATCH /tasks/:id/status {"status":"DONE","comment":"x"}` → 422 `VALIDATION_ERROR` (missing artefact)
- [ ] `PATCH /tasks/:id/status {"status":"DONE","comment":"x","artefact":"not-a-url"}` → 422 `VALIDATION_ERROR` (invalid URL)
- [ ] `PATCH /tasks/:id/status {"status":"DONE","comment":"x","artefact":"https://github.com/..."}` → 200, task has `artefact` field populated
- [ ] `GET /tasks` and `GET /tasks/:id` return `"artefact": "https://..."` for DONE tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)